### PR TITLE
"add close button" tweaks

### DIFF
--- a/lib/find-view.js
+++ b/lib/find-view.js
@@ -222,6 +222,8 @@ class FindView {
     this.handleFindEvents();
     this.handleReplaceEvents();
 
+    this.subscriptions.add(atom.config.observe("find-and-replace.showCloseButton", this.toggleCloseButton.bind(this)));
+
     this.subscriptions.add(atom.commands.add(this.findEditor.element, {
       'core:confirm': () => this.confirm(),
       'find-and-replace:confirm': () => this.confirm(),
@@ -663,6 +665,10 @@ class FindView {
         return this.model.findMarker(selectedRange);
       });
     }
+  }
+
+  toggleCloseButton(show) {
+    this.refs.closeButton.classList.toggle('hidden', !show);
   }
 
   toggleRegexOption() {

--- a/lib/find-view.js
+++ b/lib/find-view.js
@@ -471,7 +471,7 @@ class FindView {
 
   clearMessage() {
     this.element.classList.remove('has-results', 'has-no-results');
-    this.refs.descriptionLabel.innerHTML = 'Find in Current Buffer <span class="subtle-info-message">Close this panel with the <span class="highlight">esc</span> key</span>'
+    this.refs.descriptionLabel.innerHTML = 'Find in Current Buffer'
     this.refs.descriptionLabel.classList.remove('text-error');
   }
 

--- a/lib/project-find-view.js
+++ b/lib/project-find-view.js
@@ -182,6 +182,9 @@ class ProjectFindView {
   }
 
   handleEvents() {
+
+    this.subscriptions.add(atom.config.observe("find-and-replace.showCloseButton", this.toggleCloseButton.bind(this)));
+
     this.subscriptions.add(atom.commands.add('atom-workspace', {
       'find-and-replace:use-selection-as-find-pattern': () => this.setSelectionAsFindPattern()
     }));
@@ -510,6 +513,10 @@ class ProjectFindView {
     } else {
       optionButton.classList.remove('selected');
     }
+  }
+
+  toggleCloseButton(show) {
+    this.refs.closeButton.classList.toggle('hidden', !show);
   }
 
   toggleRegexOption() {

--- a/lib/project-find-view.js
+++ b/lib/project-find-view.js
@@ -414,7 +414,7 @@ class ProjectFindView {
 
   clearMessages() {
     this.element.classList.remove('has-results', 'has-no-results');
-    this.setInfoMessage('Find in Project <span class="subtle-info-message">Close this panel with the <span class="highlight">esc</span> key</span>');
+    this.setInfoMessage('Find in Project');
     this.refs.replacmentInfoBlock.style.display = 'none';
   }
 

--- a/package.json
+++ b/package.json
@@ -102,6 +102,11 @@
       "minimum": 0,
       "description": "The number of extra lines of context to show after the match for project results"
     },
+    "showCloseButton": {
+      "type": "boolean",
+      "default": true,
+      "title": "Show Close Button"
+    },
     "showSearchWrapIcon": {
       "type": "boolean",
       "default": true,

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -87,6 +87,10 @@ atom-workspace.find-visible {
     cursor: pointer;
   }
 
+  .hidden {
+    display: none;
+  }
+
   .description {
     display: inline-block;
     .subtle-info-message {

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -83,8 +83,17 @@ atom-workspace.find-visible {
   }
 
   .close-button {
-    padding-left: 10px;
+    margin-left: @component-padding;
     cursor: pointer;
+    color: @text-color-subtle;
+    &:hover {
+      color: @text-color-highlight;
+    }
+    .icon::before {
+      margin-right: 0;
+      text-align: center;
+      vertical-align: middle;
+    }
   }
 
   .hidden {


### PR DESCRIPTION
### Description of the Change

- Repositions the close button to be more center aligned, adds hover effect
- Removes the "Close this panel with the `esc` key" hint

![image](https://cloud.githubusercontent.com/assets/378023/26145144/5715bebc-3b26-11e7-994c-9e3a2f0a4462.png)

### Benefits

Looks more aligned. More space without the keybinding hint.

### Possible Drawbacks

The keybinding hint is bit harder to discover (tooltip on hover).

### Applicable Issues

This is on top of PR https://github.com/atom/find-and-replace/pull/885
